### PR TITLE
Fix for wrong audio/subs metadata due to wrong path segment

### DIFF
--- a/src/api/routes/service/service.service.ts
+++ b/src/api/routes/service/service.service.ts
@@ -1398,26 +1398,35 @@ async function mergeVideoFile(
             options.push('-c:s mov_text')
         }
 
+        const getFilename = function(path: string, ext: string, delimiter: string): string {
+            const segments = path.split(delimiter)
+        
+            if (segments.length == 0) {
+                return "unkown"
+            }
+        
+            return segments[segments.length - 1].split(ext)[0]
+        }
+        
         for (const [index, a] of audios.entries()) {
             output.addInput(a)
             options.push(`-map ${ffindex}:a:0`)
             options.push(
                 `-metadata:s:a:${index} language=${
-                    locales.find((l) => l.locale === a.split('/')[1].split('.aac')[0])
-                        ? locales.find((l) => l.locale === a.split('/')[1].split('.aac')[0])?.iso
-                        : a.split('/')[1].split('.aac')[0]
+                    locales.find((l) => l.locale === getFilename(a, '.aac', '/'))
+                        ? locales.find((l) => l.locale === getFilename(a, '.aac', '/'))?.iso
+                        : getFilename(a, '.aac', '/')
                 }`
             )
-
-            ffindex++
-
             options.push(
                 `-metadata:s:a:${index} title=${
-                    locales.find((l) => l.locale === a.split('/')[1].split('.aac')[0])
-                        ? locales.find((l) => l.locale === a.split('/')[1].split('.aac')[0])?.title
-                        : a.split('/')[1].split('.aac')[0]
+                    locales.find((l) => l.locale === getFilename(a, '.aac', '/'))
+                        ? locales.find((l) => l.locale === getFilename(a, '.aac', '/'))?.title
+                        : getFilename(a, '.aac', '/')
                 }`
             )
+            
+            ffindex++
         }
 
         options.push(`-disposition:a:0 default`)
@@ -1430,17 +1439,17 @@ async function mergeVideoFile(
                 if (s.includes('-FORCED')) {
                     options.push(
                         `-metadata:s:s:${index} language=${
-                            locales.find((l) => l.locale === s.split('/')[1].split('-FORCED.ass')[0])
-                                ? locales.find((l) => l.locale === s.split('/')[1].split('-FORCED.ass')[0])?.iso
-                                : s.split('/')[1].split('-FORCED.ass')[0]
+                            locales.find((l) => l.locale === getFilename(s, '-FORCED.ass', '/'))
+                                ? locales.find((l) => l.locale === getFilename(s, '-FORCED.ass', '/'))?.iso
+                                : getFilename(s, '-FORCED.ass', '/')
                         }`
                     )
                 } else {
                     options.push(
                         `-metadata:s:s:${index} language=${
-                            locales.find((l) => l.locale === s.split('/')[1].split('.ass')[0])
-                                ? locales.find((l) => l.locale === s.split('/')[1].split('.ass')[0])?.iso
-                                : s.split('/')[1].split('.ass')[0]
+                            locales.find((l) => l.locale === getFilename(s, '.ass', '/'))
+                                ? locales.find((l) => l.locale === getFilename(s, '.ass', '/'))?.iso
+                                : getFilename(s, '.ass', '/')
                         }`
                     )
                 }
@@ -1448,17 +1457,17 @@ async function mergeVideoFile(
                 if (s.includes('-FORCED')) {
                     options.push(
                         `-metadata:s:s:${index} title=${
-                            locales.find((l) => l.locale === s.split('/')[1].split('-FORCED.ass')[0])
-                                ? locales.find((l) => l.locale === s.split('/')[1].split('-FORCED.ass')[0])?.title
-                                : s.split('/')[1].split('-FORCED.ass')[0]
+                            locales.find((l) => l.locale === getFilename(s, '-FORCED.ass', '/'))
+                                ? locales.find((l) => l.locale === getFilename(s, '-FORCED.ass', '/'))?.title
+                                : getFilename(s, '-FORCED.ass', '/')
                         }[FORCED]`
                     )
                 } else {
                     options.push(
                         `-metadata:s:s:${index} title=${
-                            locales.find((l) => l.locale === s.split('/')[1].split('.ass')[0])
-                                ? locales.find((l) => l.locale === s.split('/')[1].split('.ass')[0])?.title
-                                : s.split('/')[1].split('.ass')[0]
+                            locales.find((l) => l.locale === getFilename(s, '.ass', '/'))
+                                ? locales.find((l) => l.locale === getFilename(s, '.ass', '/'))?.title
+                                : getFilename(s, '.ass', '/')
                         }`
                     )
                 }

--- a/src/api/routes/service/service.service.ts
+++ b/src/api/routes/service/service.service.ts
@@ -1,7 +1,7 @@
 import { Account, Playlist } from '../../db/database'
 import { downloadMPDAudio } from '../../services/audio'
 import { concatenateTSFiles } from '../../services/concatenate'
-import { checkFileExistence, createFolder, createFolderName, deleteFolder, deleteTemporaryFolders } from '../../services/folder'
+import { checkFileExistence, createFolder, createFolderName, deleteFolder, deleteTemporaryFolders, getFilename } from '../../services/folder'
 import { downloadADNSub, downloadCRSub } from '../../services/subs'
 import { CrunchyEpisode } from '../../types/crunchyroll'
 import { checkAccountMaxStreams, crunchyGetMetadata, crunchyGetPlaylist, crunchyGetPlaylistMPD } from '../crunchyroll/crunchyroll.service'
@@ -1396,16 +1396,6 @@ async function mergeVideoFile(
         var options = [chapter ? '-map_metadata 1' : '-map_metadata -1', '-metadata:s:v:0 VENDOR_ID=', '-metadata:s:v:0 language=', '-c copy', '-map 0']
         if (format === 'mp4') {
             options.push('-c:s mov_text')
-        }
-
-        const getFilename = function(path: string, ext: string, delimiter: string): string {
-            const segments = path.split(delimiter)
-        
-            if (segments.length == 0) {
-                return "unkown"
-            }
-        
-            return segments[segments.length - 1].split(ext)[0]
         }
         
         for (const [index, a] of audios.entries()) {

--- a/src/api/services/folder.ts
+++ b/src/api/services/folder.ts
@@ -100,3 +100,13 @@ export async function deleteTemporaryFolders() {
         throw error
     }
 }
+
+export function getFilename(path: string, ext: string, delimiter: string) {
+    const segments = path.split(delimiter)
+
+    if (segments.length == 0) {
+        return "unkown"
+    }
+
+    return segments[segments.length - 1].split(ext)[0]
+}


### PR DESCRIPTION
Tried to fix the issue #32 without changing too much.

The current code, such as:
```js
a.split('/')[1].split('.aac')[0]
```
always resulted in metadata that is named after the first folder of the given temporary path of the audio or subtitle file on Linux. The default /tmp path for example resulted in metadata named "tmp" (as mentioned in the comments). If the temporary folder is changed to e.g. /home/temp, the metadata language/title will also be named "home".

The change should ensure that the last segment/filename is always returned, regardless of whether it is an absolute or relative path.